### PR TITLE
Bug when migrating with data in ps_image_slider

### DIFF
--- a/src/Entity/ImageSlider.php
+++ b/src/Entity/ImageSlider.php
@@ -44,14 +44,14 @@ class ImageSlider
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="display_from", type="datetime")
+     * @ORM\Column(name="display_from", type="datetime", nullable=true)
      */
     private $display_from;
 
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="display_to", type="datetime")
+     * @ORM\Column(name="display_to", type="datetime", nullable=true)
      */
     private $display_to;
 


### PR DESCRIPTION
When running prestashop:schema:update-without-foreign while there are records in ps_image_slider the sql query becomes `ALTER TABLE ps_image_slider ADD display_from DATETIME NOT NULL, ADD display_to DATETIME NOT NULL` which throws an error because no value is set in those fields.