### PR TITLE
Fix can't save new Slide in chrome

### DIFF
--- a/src/Form/ImageSliderType.php
+++ b/src/Form/ImageSliderType.php
@@ -134,6 +134,7 @@ class ImageSliderType extends TranslatorAwareType
                 'widget' => 'single_text',
                 'html5' => true,
                 'input' => 'datetime',
+                'with_seconds' => true
             ])
             ->add('display_to', DateTimeType::class, [
                 'label' => $this->trans('Display to', TranslationDomains::TRANSLATION_DOMAIN_ADMIN),
@@ -141,6 +142,7 @@ class ImageSliderType extends TranslatorAwareType
                 'widget' => 'single_text',
                 'html5' => true,
                 'input' => 'datetime',
+                'with_seconds' => true
             ]);
 
         if ($this->isMultistoreUsed) {


### PR DESCRIPTION
Add param 'with_seconds' as stated in DateTimeType.

We need to force the browser to display the seconds by adding the HTML attribute step if not already defined. Otherwise the browser will not display and so not send the seconds therefore the value will always be considered as invalid.